### PR TITLE
chore: gate notification debug log

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -73,7 +73,9 @@ export default function Header() {
     const channel = supabase.channel(`notifications:${userId}`)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${userId}` },
         (payload) => {
-          console.log('New notification received!', payload);
+          if (import.meta.env.DEV) {
+            console.debug('New notification received!', payload);
+          }
           queryClient.invalidateQueries({ queryKey: ['notifications', userId] });
           toast({
               title: "New Notification",


### PR DESCRIPTION
## Summary
- gate notification listener logs behind `import.meta.env.DEV`

## Testing
- `npm run lint` *(fails: Unexpected any / other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68947b7d9e1083308e07a4474b2d0f01