### PR TITLE
feat: type property details

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export interface Property {
+  id: string;
+  title: string;
+  location: string;
+  price: number;
+  status: string;
+  description?: string;
+  amenities?: string[];
+  image_urls?: string[];
+  agent?: string;
+  bedrooms?: number;
+  bathrooms?: number;
+  parking?: number;
+  size?: string;
+  created_at?: string;
+}


### PR DESCRIPTION
## Summary
- define a Property interface for property data
- type PropertyDetails page with the new interface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68947b7bbfa8833086332e6e5b506e67