### PR TITLE
fix: subscribe to toast updates once

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -172,6 +172,7 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
   React.useEffect(() => {
+    // Subscribe once to toast updates
     listeners.push(setState)
     return () => {
       const index = listeners.indexOf(setState)
@@ -179,7 +180,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- refactor toast hook to subscribe only once
- document one-time subscription with a comment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68947b7ad05483308fe98e7a3509ece4