### PR TITLE
fix: improve theme toggle safety and header class

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -150,7 +150,7 @@ export default function Header() {
       </div>
 
       {/* Actions */}
-      <div className="flex items/flex items-center gap-2 md:gap-4">
+      <div className="flex items-center gap-2 md:gap-4">
         <ThemeToggle />
         {/* Notifications */}
         <DropdownMenu>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -4,11 +4,13 @@ import { Button } from "@/components/ui/button";
 
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState<boolean>(() =>
+    typeof document !== "undefined" &&
     document.documentElement.classList.contains("dark")
   );
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme");
+    if (typeof document === "undefined") return;
+    const stored = typeof window !== "undefined" ? localStorage.getItem("theme") : null;
     if (stored === "dark") {
       document.documentElement.classList.add("dark");
       setIsDark(true);
@@ -16,6 +18,7 @@ export default function ThemeToggle() {
   }, []);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
     if (isDark) {
       document.documentElement.classList.add("dark");
       localStorage.setItem("theme", "dark");


### PR DESCRIPTION
## Summary
- handle server-safe access to `document` and `localStorage` in ThemeToggle
- correct header actions container className

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a444606c833090eadbc9367ebd12