### PR TITLE
style: align Dashboard card styling with metric-card

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -137,7 +137,7 @@ interface KpiCardProps {
 
 function KpiCard({ title, value, icon: Icon }: KpiCardProps) {
   return (
-    <div className="rounded-lg border bg-card p-4">
+    <div className="metric-card p-4">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm font-medium text-muted-foreground">{title}</p>
@@ -151,7 +151,7 @@ function KpiCard({ title, value, icon: Icon }: KpiCardProps) {
   );
 }
 
-const CARD_CLASS = "rounded-lg border bg-card p-6";
+const CARD_CLASS = "metric-card";
 
 export default function Dashboard() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- refactor Dashboard KPI card to use `metric-card` styling
- reuse shared `metric-card` class for other dashboard sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / no-empty-object-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895a1e5e3148330b800ce87e113fdc6